### PR TITLE
Add work-around for shipment-rest-api

### DIFF
--- a/src/FondOfSpryker/Zed/Shipment/Business/ShipmentBusinessFactory.php
+++ b/src/FondOfSpryker/Zed/Shipment/Business/ShipmentBusinessFactory.php
@@ -4,9 +4,13 @@ namespace FondOfSpryker\Zed\Shipment\Business;
 
 use FondOfSpryker\Zed\Shipment\Business\Model\AddEmptyShipmentTransferToItem;
 use FondOfSpryker\Zed\Shipment\Business\Model\ShipmentTaxRateCalculator;
+use FondOfSpryker\Zed\Shipment\Business\ShipmentMethod\MethodPriceReader;
+use FondOfSpryker\Zed\Shipment\Business\ShipmentMethod\MethodReader;
 use FondOfSpryker\Zed\Shipment\Dependency\Facade\ShipmentToCountryFacadeInterface;
 use FondOfSpryker\Zed\Shipment\ShipmentDependencyProvider;
 use Spryker\Zed\Shipment\Business\ShipmentBusinessFactory as SprykerShipmentBusinessFactory;
+use Spryker\Zed\Shipment\Business\ShipmentMethod\MethodPriceReaderInterface;
+use Spryker\Zed\Shipment\Business\ShipmentMethod\MethodReaderInterface;
 
 /**
  * @method \FondOfSpryker\Zed\Shipment\Persistence\ShipmentQueryContainerInterface getQueryContainer()
@@ -24,6 +28,35 @@ class ShipmentBusinessFactory extends SprykerShipmentBusinessFactory
             $this->getTaxFacade(),
             $this->getShipmentService(),
             $this->getCountryFacade()
+        );
+    }
+
+    /**
+     * @return \Spryker\Zed\Shipment\Business\ShipmentMethod\MethodReaderInterface
+     */
+    public function createMethodReader(): MethodReaderInterface
+    {
+        return new MethodReader(
+            $this->getShipmentService(),
+            $this->getMethodFilterPlugins(),
+            $this->getRepository(),
+            $this->createShipmentMethodAvailabilityChecker(),
+            $this->createShipmentMethodPriceReader(),
+            $this->createShipmentMethodDeliveryTimeReader(),
+            $this->getStoreFacade()
+        );
+    }
+
+    /**
+     * @return \Spryker\Zed\Shipment\Business\ShipmentMethod\MethodPriceReaderInterface
+     */
+    public function createShipmentMethodPriceReader(): MethodPriceReaderInterface
+    {
+        return new MethodPriceReader(
+            $this->getPricePlugins(),
+            $this->getStoreFacade(),
+            $this->getRepository(),
+            $this->getCurrencyFacade()
         );
     }
 

--- a/src/FondOfSpryker/Zed/Shipment/Business/ShipmentMethod/MethodPriceReader.php
+++ b/src/FondOfSpryker/Zed/Shipment/Business/ShipmentMethod/MethodPriceReader.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FondOfSpryker\Zed\Shipment\Business\ShipmentMethod;
+
+use Generated\Shared\Transfer\QuoteTransfer;
+use Generated\Shared\Transfer\ShipmentGroupTransfer;
+use Generated\Shared\Transfer\ShipmentMethodTransfer;
+use Spryker\Zed\Shipment\Business\ShipmentMethod\MethodPriceReader as SprykerMethodPriceReader;
+
+class MethodPriceReader extends SprykerMethodPriceReader
+{
+    /**
+     * @param \Generated\Shared\Transfer\ShipmentMethodTransfer $shipmentMethodTransfer
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     * @param \Generated\Shared\Transfer\ShipmentGroupTransfer|null $shipmentGroupTransfer
+     *
+     * @return int|null
+     */
+    public function findShipmentGroupShippingPrice(
+        ShipmentMethodTransfer $shipmentMethodTransfer,
+        QuoteTransfer $quoteTransfer,
+        ?ShipmentGroupTransfer $shipmentGroupTransfer = null
+    ): ?int {
+        if (!$this->isSetPricePlugin($shipmentMethodTransfer)) {
+            return $this->findShipmentMethodPriceValue($shipmentMethodTransfer, $quoteTransfer);
+        }
+
+        if ($shipmentGroupTransfer === null) {
+            $pricePlugin = $this->getPricePlugin($shipmentMethodTransfer);
+
+            return $pricePlugin->getPrice($quoteTransfer);
+        }
+
+        return $this->getPricePluginValue($shipmentMethodTransfer, $shipmentGroupTransfer, $quoteTransfer);
+    }
+}

--- a/src/FondOfSpryker/Zed/Shipment/Business/ShipmentMethod/MethodReader.php
+++ b/src/FondOfSpryker/Zed/Shipment/Business/ShipmentMethod/MethodReader.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace FondOfSpryker\Zed\Shipment\Business\ShipmentMethod;
+
+use Generated\Shared\Transfer\QuoteTransfer;
+use Generated\Shared\Transfer\ShipmentGroupTransfer;
+use Generated\Shared\Transfer\ShipmentMethodTransfer;
+use Generated\Shared\Transfer\ShipmentTransfer;
+use Spryker\Zed\Shipment\Business\ShipmentMethod\MethodReader as SprykerMethodReader;
+
+class MethodReader extends SprykerMethodReader
+{
+    /**
+     * @param int $idShipmentMethod
+     * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
+     *
+     * @return \Generated\Shared\Transfer\ShipmentMethodTransfer|null
+     */
+    public function findAvailableMethodById(int $idShipmentMethod, QuoteTransfer $quoteTransfer): ?ShipmentMethodTransfer
+    {
+        $idStore = $this->getIdStoreFromQuote($quoteTransfer);
+        $shipmentMethodTransfer = $this->shipmentRepository->findShipmentMethodByIdAndIdStore($idShipmentMethod, $idStore);
+        if ($shipmentMethodTransfer === null) {
+            return null;
+        }
+
+        $shipmentGroupTransfer = (new ShipmentGroupTransfer())
+            ->setShipment((new ShipmentTransfer())
+                ->setMethod($shipmentMethodTransfer)
+                ->setShippingAddress($quoteTransfer->getShippingAddress()))
+            ->setItems($quoteTransfer->getItems());
+        $storeCurrencyPrice = $this->methodPriceReader
+            ->findShipmentGroupShippingPrice($shipmentMethodTransfer, $quoteTransfer, $shipmentGroupTransfer);
+        if ($storeCurrencyPrice === null) {
+            return null;
+        }
+
+        return $this->transformShipmentMethod($quoteTransfer, $shipmentMethodTransfer, $storeCurrencyPrice);
+    }
+}


### PR DESCRIPTION
Resolves an issue which is caused with the new version of spryker shipment when order happens via rest-api. 

The new structure causes custom price plugins to fail.

Discussion ref:
https://sprykercommunity.slack.com/archives/CKJRJM5FG/p1583257317042100?thread_ts=1582819353.023400&cid=CKJRJM5FG